### PR TITLE
Add optional state parameters to AsyncHelper (PHNX-12680)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,29 +12,29 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.10
+      uses: gittools/actions/gitversion/setup@v0.9.15
       with:
         versionSpec: "5.8.0"
 
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.10
+      uses: gittools/actions/gitversion/execute@v0.9.15
       with:
         useConfigFile: true
         configFilePath: "GitVersion.yml"
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
     # Cache packages for faster subsequent runs
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Restore
       working-directory: ./src
       run: >-
-        dotnet nuget add source --username USERNAME --password ${{ secrets.GH_PACKAGES_TOKEN }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/CenterEdge/index.json
+        dotnet nuget add source --name github https://nuget.pkg.github.com/CenterEdge/index.json
         && dotnet restore ./CenterEdge.Async.sln
 
     - name: Build

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -13,8 +13,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/delete-package-versions@v2
+    - uses: actions/delete-package-versions@v4
       with:
         package-name: CenterEdge.Async
+        package-type: nuget
         min-versions-to-keep: 30
         ignore-versions: ^(?!.*ci-pr).*$

--- a/src/CenterEdge.Async.Benchmarks/CenterEdge.Async.Benchmarks.csproj
+++ b/src/CenterEdge.Async.Benchmarks/CenterEdge.Async.Benchmarks.csproj
@@ -14,8 +14,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CenterEdge.Async\CenterEdge.Async.csproj" />

--- a/src/CenterEdge.Async.UnitTests/AsyncHelperTests.cs
+++ b/src/CenterEdge.Async.UnitTests/AsyncHelperTests.cs
@@ -168,6 +168,166 @@ namespace CenterEdge.Async.UnitTests
 
         #endregion
 
+        #region RunSyncWithState_Task
+
+        [Fact]
+        public void RunSyncWithState_Task_DoesAllTasks()
+        {
+            // Arrange
+
+            var i = 0;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            {
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public async Task RunSyncWithState_StartsTasksAndCompletesSynchronously_DoesAllTasks()
+        {
+            // Replicates the case where continuations are queued but the main task completes synchronously
+            // so the work must be removed from the queue
+
+            // Arrange
+
+            var i = 0;
+
+            async Task IncrementAsync()
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref i);
+            }
+
+            // Act
+            AsyncHelper.RunSync(state =>
+            {
+#pragma warning disable CS4014
+                for (var j = 0; j < 3; j++)
+                {
+                    var _ = IncrementAsync();
+                }
+#pragma warning restore CS4014
+
+                return Task.CompletedTask;
+            }, 1);
+
+            // Assert
+
+            await Task.Delay(500);
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_Task_ConfigureAwaitFalse_DoesAllTasks()
+        {
+            // Arrange
+
+            var i = 0;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            {
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_Task_ExceptionAfterAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+                {
+                    await Task.Delay(10);
+
+                    throw new InvalidOperationException();
+                }), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_Task_ExceptionBeforeAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, Task>)(_ => throw new InvalidOperationException()), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_Task_ThrowsException_ResetsSyncContext()
+        {
+            // Arrange
+
+            var sync = new SynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(sync);
+
+            // Act
+            try
+            {
+                AsyncHelper.RunSync((Func<int, Task>)(_ => throw new InvalidOperationException()), 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            // Assert
+
+            Assert.Equal(sync, SynchronizationContext.Current);
+        }
+
+        [Fact]
+        public void RunSyncWithState_Task_DanglingContinuations_HandledOnParentSyncContext()
+        {
+            // Arrange
+
+            var mockSync = new Mock<SynchronizationContext> { CallBase = true };
+            SynchronizationContext.SetSynchronizationContext(mockSync.Object);
+
+            var called = false;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            {
+                await Task.Yield();
+
+#pragma warning disable 4014
+                DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
+#pragma warning restore 4014
+            }), 1);
+
+            // Assert
+
+            Assert.False(called);
+
+            Thread.Sleep(500);
+
+            Assert.True(called);
+
+            mockSync.Verify(
+                m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()),
+                Times.Once);
+        }
+
+        #endregion
+
         #region RunSync_ValueTask
 
         [Fact]
@@ -312,6 +472,166 @@ namespace CenterEdge.Async.UnitTests
                 DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
 #pragma warning restore 4014
             }));
+
+            // Assert
+
+            Assert.False(called);
+
+            Thread.Sleep(500);
+
+            Assert.True(called);
+
+            mockSync.Verify(
+                m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()),
+                Times.Once);
+        }
+
+        #endregion
+
+        #region RunSyncWithState_ValueTask
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_DoesAllTasks()
+        {
+            // Arrange
+
+            var i = 0;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            {
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public async Task RunSyncWithState_ValueTask_StartsTasksAndCompletesSynchronously_DoesAllTasks()
+        {
+            // Replicates the case where continuations are queued but the main task completes synchronously
+            // so the work must be removed from the queue
+
+            // Arrange
+
+            var i = 0;
+
+            async Task IncrementAsync()
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref i);
+            }
+
+            // Act
+            AsyncHelper.RunSync(state =>
+            {
+#pragma warning disable CS4014
+                for (var j = 0; j < 3; j++)
+                {
+                    var _ = IncrementAsync();
+                }
+#pragma warning restore CS4014
+
+                return new ValueTask();
+            }, 1);
+
+            // Assert
+
+            await Task.Delay(500);
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_ConfigureAwaitFalse_DoesAllTasks()
+        {
+            // Arrange
+
+            var i = 0;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            {
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_ExceptionAfterAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+                {
+                    await Task.Delay(10);
+
+                    throw new InvalidOperationException();
+                }), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_ExceptionBeforeAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, ValueTask>)(_ => throw new InvalidOperationException()), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_ThrowsException_ResetsSyncContext()
+        {
+            // Arrange
+
+            var sync = new SynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(sync);
+
+            // Act
+            try
+            {
+                AsyncHelper.RunSync((Func<int, ValueTask>)(_ => throw new InvalidOperationException()), 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            // Assert
+
+            Assert.Equal(sync, SynchronizationContext.Current);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTask_DanglingContinuations_HandledOnParentSyncContext()
+        {
+            // Arrange
+
+            var mockSync = new Mock<SynchronizationContext> { CallBase = true };
+            SynchronizationContext.SetSynchronizationContext(mockSync.Object);
+
+            var called = false;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            {
+                await Task.Yield();
+
+#pragma warning disable 4014
+                DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
+#pragma warning restore 4014
+            }), 1);
 
             // Assert
 
@@ -484,6 +804,162 @@ namespace CenterEdge.Async.UnitTests
 
         #endregion
 
+        #region RunSyncWithState_TaskT
+
+        [Fact]
+        public void RunSyncWithState_TaskT_DoesAllTasks()
+        {
+            // Act
+            var result = AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            {
+                var i = 1;
+                await Task.Delay(10);
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+                return i;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public async Task RunSyncWithState_TaskT_StartsTasksAndCompletesSynchronously_DoesAllTasks()
+        {
+            // Replicates the case where continuations are queued but the main task completes synchronously
+            // so the work must be removed from the queue
+
+            // Arrange
+
+            var i = 0;
+
+            async Task IncrementAsync()
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref i);
+            }
+
+            // Act
+            AsyncHelper.RunSync(state =>
+            {
+#pragma warning disable CS4014
+                for (var j = 0; j < 3; j++)
+                {
+                    var _ = IncrementAsync();
+                }
+#pragma warning restore CS4014
+
+                return Task.FromResult(true);
+            }, 1);
+
+            // Assert
+
+            await Task.Delay(500);
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_TaskT_ConfigureAwaitFalse_DoesAllTasks()
+        {
+            // Act
+            var result = AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            {
+                var i = 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                return i;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public void RunSyncWithState_TaskT_ExceptionAfterAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+                {
+                    await Task.Delay(10);
+
+                    throw new InvalidOperationException();
+                }), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_TaskT_ExceptionBeforeAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, Task<int>>)(_ => throw new InvalidOperationException()), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_TaskT_ThrowsException_ResetsSyncContext()
+        {
+            // Arrange
+
+            var sync = new SynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(sync);
+
+            // Act
+            try
+            {
+                AsyncHelper.RunSync((Func<int, Task<object>>)(_ => throw new InvalidOperationException()), 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            // Assert
+
+            Assert.Equal(sync, SynchronizationContext.Current);
+        }
+
+        [Fact]
+        public void RunSyncWithState_TaskT_DanglingContinuations_HandledOnParentSyncContext()
+        {
+            // Arrange
+
+            var mockSync = new Mock<SynchronizationContext> { CallBase = true };
+            SynchronizationContext.SetSynchronizationContext(mockSync.Object);
+
+            var called = false;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            {
+                await Task.Yield();
+
+#pragma warning disable 4014
+                DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
+#pragma warning restore 4014
+
+                return 0;
+            }), 1);
+
+            // Assert
+
+            Assert.False(called);
+
+            Thread.Sleep(500);
+
+            Assert.True(called);
+
+            mockSync.Verify(
+                m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()),
+                Times.Once);
+        }
+
+        #endregion
+
         #region RunSync_ValueTaskT
 
         [Fact]
@@ -624,6 +1100,162 @@ namespace CenterEdge.Async.UnitTests
 
                 return 0;
             }));
+
+            // Assert
+
+            Assert.False(called);
+
+            Thread.Sleep(500);
+
+            Assert.True(called);
+
+            mockSync.Verify(
+                m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()),
+                Times.Once);
+        }
+
+        #endregion
+
+        #region RunSyncWithState_ValueTaskT
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_DoesAllTasks()
+        {
+            // Act
+            var result = AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            {
+                var i = 1;
+                await Task.Delay(10);
+                i += 1;
+                await Task.Delay(10);
+                i += 1;
+                return i;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public async Task RunSyncWithState_ValueTaskT_StartsTasksAndCompletesSynchronously_DoesAllTasks()
+        {
+            // Replicates the case where continuations are queued but the main task completes synchronously
+            // so the work must be removed from the queue
+
+            // Arrange
+
+            var i = 0;
+
+            async Task IncrementAsync()
+            {
+                await Task.Yield();
+                Interlocked.Increment(ref i);
+            }
+
+            // Act
+            AsyncHelper.RunSync(state =>
+            {
+#pragma warning disable CS4014
+                for (var j = 0; j < 3; j++)
+                {
+                    var _ = IncrementAsync();
+                }
+#pragma warning restore CS4014
+
+                return new ValueTask<bool>(true);
+            }, 1);
+
+            // Assert
+
+            await Task.Delay(500);
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_ConfigureAwaitFalse_DoesAllTasks()
+        {
+            // Act
+            var result = AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            {
+                var i = 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                await Task.Delay(10).ConfigureAwait(false);
+                i += 1;
+                return i;
+            }), 1);
+
+            // Assert
+
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_ExceptionAfterAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+                {
+                    await Task.Delay(10);
+
+                    throw new InvalidOperationException();
+                }), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_ExceptionBeforeAwait_ThrowsException()
+        {
+            // Act/Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                AsyncHelper.RunSync((Func<int, ValueTask<int>>)(_ => throw new InvalidOperationException()), 1));
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_ThrowsException_ResetsSyncContext()
+        {
+            // Arrange
+
+            var sync = new SynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(sync);
+
+            // Act
+            try
+            {
+                AsyncHelper.RunSync((Func<int, ValueTask<object>>)(_ => throw new InvalidOperationException()), 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            // Assert
+
+            Assert.Equal(sync, SynchronizationContext.Current);
+        }
+
+        [Fact]
+        public void RunSyncWithState_ValueTaskT_DanglingContinuations_HandledOnParentSyncContext()
+        {
+            // Arrange
+
+            var mockSync = new Mock<SynchronizationContext> { CallBase = true };
+            SynchronizationContext.SetSynchronizationContext(mockSync.Object);
+
+            var called = false;
+
+            // Act
+            AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            {
+                await Task.Yield();
+
+#pragma warning disable 4014
+                DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
+#pragma warning restore 4014
+
+                return 0;
+            }), 1);
 
             // Assert
 

--- a/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
+++ b/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
@@ -10,19 +10,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
+++ b/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
@@ -19,7 +19,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/CenterEdge.Async/AsyncHelper.cs
+++ b/src/CenterEdge.Async/AsyncHelper.cs
@@ -19,7 +19,7 @@ namespace CenterEdge.Async
         /// <summary>
         /// Executes an async <see cref="Task"/> method with no return value synchronously.
         /// </summary>
-        /// <param name="task"><see cref="Task"/> method to execute</param>
+        /// <param name="task"><see cref="Task"/> method to execute.</param>
         /// <remarks>
         /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
@@ -52,9 +52,45 @@ namespace CenterEdge.Async
         }
 
         /// <summary>
+        /// Executes an async <see cref="Task"/> method with no return value synchronously.
+        /// </summary>
+        /// <param name="task"><see cref="Task"/> method to execute.</param>
+        /// <param name="state">State to pass to the method.</param>
+        /// <remarks>
+        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+        /// </remarks>
+        public static void RunSync<TState>(Func<TState, Task> task, TState state)
+        {
+            var oldContext = SynchronizationContext.Current;
+            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter>(oldContext);
+            SynchronizationContext.SetSynchronizationContext(synch);
+            try
+            {
+                var awaiter = task(state).GetAwaiter();
+
+                if (!awaiter.IsCompleted)
+                {
+                    synch.Run(awaiter);
+                }
+                else
+                {
+                    synch.RunAlreadyComplete();
+                }
+
+                // Throw any exception returned by the task
+                awaiter.GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        /// <summary>
         /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
         /// </summary>
-        /// <param name="task"><see cref="ValueTask"/> method to execute</param>
+        /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
         /// <remarks>
         /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
@@ -87,9 +123,45 @@ namespace CenterEdge.Async
         }
 
         /// <summary>
+        /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
+        /// </summary>
+        /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
+        /// <param name="state">State to pass to the method.</param>
+        /// <remarks>
+        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+        /// </remarks>
+        public static void RunSync<TState>(Func<TState, ValueTask> task, TState state)
+        {
+            var oldContext = SynchronizationContext.Current;
+            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter>(oldContext);
+            SynchronizationContext.SetSynchronizationContext(synch);
+            try
+            {
+                var awaiter = task(state).GetAwaiter();
+
+                if (!awaiter.IsCompleted)
+                {
+                    synch.Run(awaiter);
+                }
+                else
+                {
+                    synch.RunAlreadyComplete();
+                }
+
+                // Throw any exception returned by the task
+                awaiter.GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        /// <summary>
         /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
         /// </summary>
-        /// <param name="task"><see cref="Task{T}"/> method to execute</param>
+        /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
         /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
@@ -123,9 +195,46 @@ namespace CenterEdge.Async
         }
 
         /// <summary>
+        /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
+        /// </summary>
+        /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
+        /// <param name="state">State to pass to the method.</param>
+        /// <returns>The asynchronous result.</returns>
+        /// <remarks>
+        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+        /// </remarks>
+        public static T RunSync<T, TState>(Func<TState, Task<T>> task, TState state)
+        {
+            var oldContext = SynchronizationContext.Current;
+            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter<T>>(oldContext);
+            SynchronizationContext.SetSynchronizationContext(synch);
+            try
+            {
+                var awaiter = task(state).GetAwaiter();
+
+                if (!awaiter.IsCompleted)
+                {
+                    synch.Run(awaiter);
+                }
+                else
+                {
+                    synch.RunAlreadyComplete();
+                }
+
+                // Throw any exception returned by the task or return the result
+                return awaiter.GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        /// <summary>
         /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
         /// </summary>
-        /// <param name="task"><see cref="ValueTask{T}"/> method to execute</param>
+        /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
         /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
@@ -139,6 +248,43 @@ namespace CenterEdge.Async
             try
             {
                 var awaiter = task().GetAwaiter();
+
+                if (!awaiter.IsCompleted)
+                {
+                    synch.Run(awaiter);
+                }
+                else
+                {
+                    synch.RunAlreadyComplete();
+                }
+
+                // Throw any exception returned by the task or return the result
+                return awaiter.GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        /// <summary>
+        /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
+        /// </summary>
+        /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
+        /// <param name="state">State to pass to the method.</param>
+        /// <returns>The asynchronous result.</returns>
+        /// <remarks>
+        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+        /// </remarks>
+        public static T RunSync<T, TState>(Func<TState, ValueTask<T>> task, TState state)
+        {
+            var oldContext = SynchronizationContext.Current;
+            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter<T>>(oldContext);
+            SynchronizationContext.SetSynchronizationContext(synch);
+            try
+            {
+                var awaiter = task(state).GetAwaiter();
 
                 if (!awaiter.IsCompleted)
                 {

--- a/src/CenterEdge.Async/AsyncHelper.cs
+++ b/src/CenterEdge.Async/AsyncHelper.cs
@@ -21,7 +21,7 @@ namespace CenterEdge.Async
         /// </summary>
         /// <param name="task"><see cref="Task"/> method to execute.</param>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static void RunSync(Func<Task> task)
@@ -57,7 +57,7 @@ namespace CenterEdge.Async
         /// <param name="task"><see cref="Task"/> method to execute.</param>
         /// <param name="state">State to pass to the method.</param>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static void RunSync<TState>(Func<TState, Task> task, TState state)
@@ -92,7 +92,7 @@ namespace CenterEdge.Async
         /// </summary>
         /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static void RunSync(Func<ValueTask> task)
@@ -128,7 +128,7 @@ namespace CenterEdge.Async
         /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
         /// <param name="state">State to pass to the method.</param>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static void RunSync<TState>(Func<TState, ValueTask> task, TState state)
@@ -164,7 +164,7 @@ namespace CenterEdge.Async
         /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static T RunSync<T>(Func<Task<T>> task)
@@ -201,7 +201,7 @@ namespace CenterEdge.Async
         /// <param name="state">State to pass to the method.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static T RunSync<T, TState>(Func<TState, Task<T>> task, TState state)
@@ -237,7 +237,7 @@ namespace CenterEdge.Async
         /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static T RunSync<T>(Func<ValueTask<T>> task)
@@ -274,7 +274,7 @@ namespace CenterEdge.Async
         /// <param name="state">State to pass to the method.</param>
         /// <returns>The asynchronous result.</returns>
         /// <remarks>
-        /// DO NOT use this methods unless absolutely necessary. Calling async code from sync code is an anti-pattern
+        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
         /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
         /// </remarks>
         public static T RunSync<T, TState>(Func<TState, ValueTask<T>> task, TState state)

--- a/src/CenterEdge.Async/CenterEdge.Async.csproj
+++ b/src/CenterEdge.Async/CenterEdge.Async.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CenterEdge.Async/CenterEdge.Async.csproj
+++ b/src/CenterEdge.Async/CenterEdge.Async.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
 
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Motivation
----------
In some scenarios this can reduce heap allocations of closures.

Modifications
-------------
Add the optional state parameter and matching unit tests.

Drop .NET 5 target since it is EOL and target .NET 6.

https://centeredge.atlassian.net/browse/PHNX-12680
