### PR TITLE
Apply various modernizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,34 +12,33 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
+          9.0.x
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.15
+      uses: gittools/actions/gitversion/setup@v4
       with:
-        versionSpec: "5.8.0"
+        versionSpec: "6.4.0"
 
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.15
+      uses: gittools/actions/gitversion/execute@v4
       with:
-        useConfigFile: true
         configFilePath: "GitVersion.yml"
 
     # Cache packages for faster subsequent runs
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'nuget.config') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
 
@@ -53,19 +52,11 @@ jobs:
 
     - name: Test
       working-directory: ./src
-      run: dotnet test --no-build -c Release -f net8.0 -l 'trx;LogFileName=results.trx' ./CenterEdge.Async.sln
-
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure() # run this step even if previous step failed
-      with:
-        name: Unit Tests
-        path: src/**/results.trx
-        reporter: dotnet-trx
+      run: dotnet test --no-build -c Release -f net8.0 -l "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true" ./CenterEdge.Async.sln
 
     - name: Pack
       working-directory: ./src
-      run: dotnet pack --no-build -c Release /p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersionV2 }} ./CenterEdge.Async.sln
+      run: dotnet pack --no-build -c Release /p:PackageVersion=${{ steps.gitversion.outputs.fullSemVer }} ./CenterEdge.Async.sln
 
     - name: Push
       working-directory: ./src
@@ -73,10 +64,10 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/pull/') }}
       run: |
         dotnet nuget add source --name github https://nuget.pkg.github.com/CenterEdge/index.json &&
-        dotnet nuget push **/*.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -k ${{ secrets.GITHUB_TOKEN  }} -s github
+        dotnet nuget push **/*.${{ steps.gitversion.outputs.fullSemVer }}.nupkg -k ${{ secrets.GITHUB_TOKEN  }} -s github
 
     - name: Push to NuGet.org
       working-directory: ./src
       # Publish tagged releases to NuGet.org
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: dotnet nuget push **/*.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s nuget.org
+      run: dotnet nuget push **/*.${{ steps.gitversion.outputs.fullSemVer }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s nuget.org

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/delete-package-versions@v4
+    - uses: actions/delete-package-versions@v5
       with:
         package-name: CenterEdge.Async
         package-type: nuget

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,8 +2,13 @@ mode: ContinuousDelivery
 branches:
   pull-request:
     mode: ContinuousDeployment
-    tag: ci-pr-
+    label: ci-pr-
     track-merge-target: true
+  tags:
+    regex: tags/(?<tag>.+)
+    label: ''
+    source-branches:
+      - main
 ignore:
   sha: []
 merge-message-formats: {}

--- a/src/CenterEdge.Async.Benchmarks/CenterEdge.Async.Benchmarks.csproj
+++ b/src/CenterEdge.Async.Benchmarks/CenterEdge.Async.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -13,8 +13,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.11" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CenterEdge.Async\CenterEdge.Async.csproj" />

--- a/src/CenterEdge.Async.UnitTests/AsyncHelperTests.cs
+++ b/src/CenterEdge.Async.UnitTests/AsyncHelperTests.cs
@@ -22,14 +22,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<Task>)(async () =>
+            AsyncHelper.RunSync(async () =>
             {
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
-            }));
+            });
 
             // Assert
 
@@ -67,7 +67,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -79,14 +79,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<Task>)(async () =>
+            AsyncHelper.RunSync(async () =>
             {
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
-            }));
+            });
 
             // Assert
 
@@ -98,12 +98,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<Task>)(async () =>
+                AsyncHelper.RunSync(async () =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                })));
+                }));
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<Task>)(() => throw new InvalidOperationException())));
+                AsyncHelper.RunSync(() => throw new InvalidOperationException()));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<Task>)(() => throw new InvalidOperationException()));
+                AsyncHelper.RunSync(() => throw new InvalidOperationException());
             }
             catch (InvalidOperationException)
             {
@@ -148,14 +148,14 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<Task>)(async () =>
+            AsyncHelper.RunSync(async () =>
             {
                 await Task.Yield();
 
 #pragma warning disable 4014
                 DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
 #pragma warning restore 4014
-            }));
+            });
 
             // Assert
 
@@ -182,14 +182,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            AsyncHelper.RunSync(async _ =>
             {
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -227,7 +227,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -239,14 +239,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            AsyncHelper.RunSync(async _ =>
             {
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -258,12 +258,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+                AsyncHelper.RunSync(async _ =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                }), 1));
+                }, 1));
         }
 
         [Fact]
@@ -271,7 +271,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, Task>)(_ => throw new InvalidOperationException()), 1));
+                AsyncHelper.RunSync(_ => throw new InvalidOperationException(), 1));
         }
 
         [Fact]
@@ -285,7 +285,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<int, Task>)(_ => throw new InvalidOperationException()), 1);
+                AsyncHelper.RunSync(_ => throw new InvalidOperationException(), 1);
             }
             catch (InvalidOperationException)
             {
@@ -308,14 +308,14 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<int, Task>)(async _ =>
+            AsyncHelper.RunSync(async _ =>
             {
                 await Task.Yield();
 
 #pragma warning disable 4014
                 DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
 #pragma warning restore 4014
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -342,14 +342,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<ValueTask>)(async () =>
+            AsyncHelper.RunSync(async ValueTask () =>
             {
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
-            }));
+            });
 
             // Assert
 
@@ -387,7 +387,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -399,14 +399,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<ValueTask>)(async () =>
+            AsyncHelper.RunSync(async ValueTask () =>
             {
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
-            }));
+            });
 
             // Assert
 
@@ -418,12 +418,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<ValueTask>)(async () =>
+                AsyncHelper.RunSync(async ValueTask () =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                })));
+                }));
         }
 
         [Fact]
@@ -431,7 +431,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<ValueTask>)(() => throw new InvalidOperationException())));
+                AsyncHelper.RunSync(ValueTask () => throw new InvalidOperationException()));
         }
 
         [Fact]
@@ -445,7 +445,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<ValueTask>)(() => throw new InvalidOperationException()));
+                AsyncHelper.RunSync(ValueTask () => throw new InvalidOperationException());
             }
             catch (InvalidOperationException)
             {
@@ -468,14 +468,14 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<ValueTask>)(async () =>
+            AsyncHelper.RunSync(async ValueTask () =>
             {
                 await Task.Yield();
 
 #pragma warning disable 4014
                 DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
 #pragma warning restore 4014
-            }));
+            });
 
             // Assert
 
@@ -502,14 +502,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            AsyncHelper.RunSync(async ValueTask (state) =>
             {
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
                 await Task.Delay(10);
                 i += 1;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -547,7 +547,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -559,14 +559,14 @@ namespace CenterEdge.Async.UnitTests
             var i = 0;
 
             // Act
-            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            AsyncHelper.RunSync(async ValueTask (state) =>
             {
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -578,12 +578,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+                AsyncHelper.RunSync(async ValueTask (state) =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                }), 1));
+                }, 1));
         }
 
         [Fact]
@@ -591,7 +591,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, ValueTask>)(_ => throw new InvalidOperationException()), 1));
+                AsyncHelper.RunSync(ValueTask (_) => throw new InvalidOperationException(), 1));
         }
 
         [Fact]
@@ -605,7 +605,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<int, ValueTask>)(_ => throw new InvalidOperationException()), 1);
+                AsyncHelper.RunSync(ValueTask (_) => throw new InvalidOperationException(), 1);
             }
             catch (InvalidOperationException)
             {
@@ -628,14 +628,14 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<int, ValueTask>)(async state =>
+            AsyncHelper.RunSync(async ValueTask (state) =>
             {
                 await Task.Yield();
 
 #pragma warning disable 4014
                 DelayedActionAsync(TimeSpan.FromMilliseconds(400), () => called = true);
 #pragma warning restore 4014
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -658,7 +658,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSync_TaskT_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<Task<int>>)(async () =>
+            var result = AsyncHelper.RunSync(async () =>
             {
                 var i = 1;
                 await Task.Delay(10);
@@ -666,7 +666,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10);
                 i += 1;
                 return i;
-            }));
+            });
 
             // Assert
 
@@ -704,7 +704,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -712,7 +712,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSync_TaskT_ConfigureAwaitFalse_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<Task<int>>)(async () =>
+            var result = AsyncHelper.RunSync(async () =>
             {
                 var i = 1;
                 await Task.Delay(10).ConfigureAwait(false);
@@ -720,7 +720,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 return i;
-            }));
+            });
 
             // Assert
 
@@ -732,12 +732,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<Task<int>>)(async () =>
+                AsyncHelper.RunSync(async () =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                })));
+                }));
         }
 
         [Fact]
@@ -745,7 +745,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<Task<int>>)(() => throw new InvalidOperationException())));
+                AsyncHelper.RunSync(() => throw new InvalidOperationException()));
         }
 
         [Fact]
@@ -759,7 +759,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<Task<object>>)(() => throw new InvalidOperationException()));
+                AsyncHelper.RunSync(() => throw new InvalidOperationException());
             }
             catch (InvalidOperationException)
             {
@@ -782,7 +782,7 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<Task<int>>)(async () =>
+            AsyncHelper.RunSync(async () =>
             {
                 await Task.Yield();
 
@@ -791,7 +791,7 @@ namespace CenterEdge.Async.UnitTests
 #pragma warning restore 4014
 
                 return 0;
-            }));
+            });
 
             // Assert
 
@@ -814,7 +814,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSyncWithState_TaskT_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            var result = AsyncHelper.RunSync(async state =>
             {
                 var i = 1;
                 await Task.Delay(10);
@@ -822,7 +822,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10);
                 i += 1;
                 return i;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -860,7 +860,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -868,7 +868,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSyncWithState_TaskT_ConfigureAwaitFalse_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            var result = AsyncHelper.RunSync(async state =>
             {
                 var i = 1;
                 await Task.Delay(10).ConfigureAwait(false);
@@ -876,7 +876,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 return i;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -888,12 +888,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+                AsyncHelper.RunSync(async state =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                }), 1));
+                }, 1));
         }
 
         [Fact]
@@ -901,7 +901,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, Task<int>>)(_ => throw new InvalidOperationException()), 1));
+                AsyncHelper.RunSync(_ => throw new InvalidOperationException(), 1));
         }
 
         [Fact]
@@ -915,7 +915,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<int, Task<object>>)(_ => throw new InvalidOperationException()), 1);
+                AsyncHelper.RunSync(_ => throw new InvalidOperationException(), 1);
             }
             catch (InvalidOperationException)
             {
@@ -938,7 +938,7 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<int, Task<int>>)(async state =>
+            AsyncHelper.RunSync(async state =>
             {
                 await Task.Yield();
 
@@ -947,7 +947,7 @@ namespace CenterEdge.Async.UnitTests
 #pragma warning restore 4014
 
                 return 0;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -970,7 +970,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSync_ValueTaskT_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<ValueTask<int>>)(async () =>
+            var result = AsyncHelper.RunSync(async ValueTask<int> () =>
             {
                 var i = 1;
                 await Task.Delay(10);
@@ -978,7 +978,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10);
                 i += 1;
                 return i;
-            }));
+            });
 
             // Assert
 
@@ -1016,7 +1016,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -1024,7 +1024,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSync_ValueTaskT_ConfigureAwaitFalse_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<ValueTask<int>>)(async () =>
+            var result = AsyncHelper.RunSync(async ValueTask<int> () =>
             {
                 var i = 1;
                 await Task.Delay(10).ConfigureAwait(false);
@@ -1032,7 +1032,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 return i;
-            }));
+            });
 
             // Assert
 
@@ -1044,12 +1044,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<ValueTask<int>>)(async () =>
+                AsyncHelper.RunSync(async ValueTask<int> () =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                })));
+                }));
         }
 
         [Fact]
@@ -1057,7 +1057,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<ValueTask<int>>)(() => throw new InvalidOperationException())));
+                AsyncHelper.RunSync(ValueTask<int> () => throw new InvalidOperationException()));
         }
 
         [Fact]
@@ -1071,7 +1071,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<ValueTask<object>>)(() => throw new InvalidOperationException()));
+                AsyncHelper.RunSync(ValueTask<int> () => throw new InvalidOperationException());
             }
             catch (InvalidOperationException)
             {
@@ -1094,7 +1094,7 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<ValueTask<int>>)(async () =>
+            AsyncHelper.RunSync(async ValueTask<int> () =>
             {
                 await Task.Yield();
 
@@ -1103,7 +1103,7 @@ namespace CenterEdge.Async.UnitTests
 #pragma warning restore 4014
 
                 return 0;
-            }));
+            });
 
             // Assert
 
@@ -1126,7 +1126,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSyncWithState_ValueTaskT_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            var result = AsyncHelper.RunSync(async ValueTask<int> (state) =>
             {
                 var i = 1;
                 await Task.Delay(10);
@@ -1134,7 +1134,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10);
                 i += 1;
                 return i;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -1172,7 +1172,7 @@ namespace CenterEdge.Async.UnitTests
 
             // Assert
 
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             Assert.Equal(3, i);
         }
 
@@ -1180,7 +1180,7 @@ namespace CenterEdge.Async.UnitTests
         public void RunSyncWithState_ValueTaskT_ConfigureAwaitFalse_DoesAllTasks()
         {
             // Act
-            var result = AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            var result = AsyncHelper.RunSync(async ValueTask<int> (state) =>
             {
                 var i = 1;
                 await Task.Delay(10).ConfigureAwait(false);
@@ -1188,7 +1188,7 @@ namespace CenterEdge.Async.UnitTests
                 await Task.Delay(10).ConfigureAwait(false);
                 i += 1;
                 return i;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -1200,12 +1200,12 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+                AsyncHelper.RunSync(async ValueTask<int> (state) =>
                 {
                     await Task.Delay(10);
 
                     throw new InvalidOperationException();
-                }), 1));
+                }, 1));
         }
 
         [Fact]
@@ -1213,7 +1213,7 @@ namespace CenterEdge.Async.UnitTests
         {
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() =>
-                AsyncHelper.RunSync((Func<int, ValueTask<int>>)(_ => throw new InvalidOperationException()), 1));
+                AsyncHelper.RunSync(ValueTask<int> (_) => throw new InvalidOperationException(), 1));
         }
 
         [Fact]
@@ -1227,7 +1227,7 @@ namespace CenterEdge.Async.UnitTests
             // Act
             try
             {
-                AsyncHelper.RunSync((Func<int, ValueTask<object>>)(_ => throw new InvalidOperationException()), 1);
+                AsyncHelper.RunSync(ValueTask<int> (_) => throw new InvalidOperationException(), 1);
             }
             catch (InvalidOperationException)
             {
@@ -1250,7 +1250,7 @@ namespace CenterEdge.Async.UnitTests
             var called = false;
 
             // Act
-            AsyncHelper.RunSync((Func<int, ValueTask<int>>)(async state =>
+            AsyncHelper.RunSync(async ValueTask<int> (state) =>
             {
                 await Task.Yield();
 
@@ -1259,7 +1259,7 @@ namespace CenterEdge.Async.UnitTests
 #pragma warning restore 4014
 
                 return 0;
-            }), 1);
+            }, 1);
 
             // Assert
 
@@ -1280,7 +1280,7 @@ namespace CenterEdge.Async.UnitTests
 
         private static readonly AsyncLocal<int> asyncLocalField = new();
 
-        private async Task DelayedActionAsync(TimeSpan delay, Action action)
+        private async static Task DelayedActionAsync(TimeSpan delay, Action action)
         {
             await Task.Delay(delay);
 

--- a/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
+++ b/src/CenterEdge.Async.UnitTests/CenterEdge.Async.UnitTests.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>13</LangVersion>
 
     <Nullable>warnings</Nullable>
 
@@ -9,21 +11,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CenterEdge.Async/AsyncHelper.cs
+++ b/src/CenterEdge.Async/AsyncHelper.cs
@@ -5,423 +5,356 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CenterEdge.Async
+namespace CenterEdge.Async;
+
+/// <summary>
+/// Executes asynchronous tasks synchronously.
+/// </summary>
+/// <remarks>
+/// DO NOT use this class unless absolutely necessary. Calling async code from sync code is an anti-pattern
+/// in most cases. This class is provided to assist in gradual conversion from sync to async code.
+/// </remarks>
+public static class AsyncHelper
 {
+    // ValueTask-based overloads include OverloadResolutionPriority(-1) so that C# 13 and later will prefer the Task-based
+    // overloads by default when both are applicable. This occurs when passing an async lambda directly to the RunSync method
+    // without an explicit return type, for example:
+    //
+    //     AsyncHelper.RunSync(async () =>
+    //     {
+    //         await DoSomething();
+    //         await DoSomethingElse();
+    //     });
+
     /// <summary>
-    /// Executes asynchronous tasks synchronously.
+    /// Executes an async <see cref="Task"/> method with no return value synchronously.
     /// </summary>
+    /// <param name="task"><see cref="Task"/> method to execute.</param>
     /// <remarks>
-    /// DO NOT use this class unless absolutely necessary. Calling async code from sync code is an anti-pattern
-    /// in most cases. This class is provided to assist in gradual conversion from sync to async code.
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
     /// </remarks>
-    public static class AsyncHelper
+    public static void RunSync(Func<Task> task)
     {
-        /// <summary>
-        /// Executes an async <see cref="Task"/> method with no return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="Task"/> method to execute.</param>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static void RunSync(Func<Task> task)
+        RunSync(static state => state.Invoke(), task);
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="Task"/> method with no return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="Task"/> method to execute.</param>
+    /// <param name="state">State to pass to the method.</param>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    public static void RunSync<TState>(Func<TState, Task> task, TState state)
+    {
+        var oldContext = SynchronizationContext.Current;
+        using var synch = new ExclusiveSynchronizationContext<TaskAwaiter>(oldContext);
+        SynchronizationContext.SetSynchronizationContext(synch);
+        try
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
-            {
-                var awaiter = task().GetAwaiter();
+            var awaiter = task(state).GetAwaiter();
 
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task
-                awaiter.GetResult();
-            }
-            finally
+            if (!awaiter.IsCompleted)
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                synch.Run(awaiter);
             }
+            else
+            {
+                synch.RunAlreadyComplete();
+            }
+
+            // Throw any exception returned by the task
+            awaiter.GetResult();
         }
-
-        /// <summary>
-        /// Executes an async <see cref="Task"/> method with no return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="Task"/> method to execute.</param>
-        /// <param name="state">State to pass to the method.</param>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static void RunSync<TState>(Func<TState, Task> task, TState state)
+        finally
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
-            {
-                var awaiter = task(state).GetAwaiter();
-
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task
-                awaiter.GetResult();
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
-            }
+            SynchronizationContext.SetSynchronizationContext(oldContext);
         }
+    }
 
-        /// <summary>
-        /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static void RunSync(Func<ValueTask> task)
+    /// <summary>
+    /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    [OverloadResolutionPriority(-1)]
+    public static void RunSync(Func<ValueTask> task)
+    {
+        RunSync(static state => state.Invoke(), task);
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
+    /// <param name="state">State to pass to the method.</param>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    [OverloadResolutionPriority(-1)]
+    public static void RunSync<TState>(Func<TState, ValueTask> task, TState state)
+    {
+        var oldContext = SynchronizationContext.Current;
+        using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter>(oldContext);
+        SynchronizationContext.SetSynchronizationContext(synch);
+        try
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
-            {
 #pragma warning disable CA2012
-                var awaiter = task().GetAwaiter();
+            var awaiter = task(state).GetAwaiter();
 #pragma warning restore CA2012
 
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task
-                awaiter.GetResult();
-            }
-            finally
+            if (!awaiter.IsCompleted)
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                synch.Run(awaiter);
             }
+            else
+            {
+                synch.RunAlreadyComplete();
+            }
+
+            // Throw any exception returned by the task
+            awaiter.GetResult();
         }
-
-        /// <summary>
-        /// Executes an async <see cref="ValueTask"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="ValueTask"/> method to execute.</param>
-        /// <param name="state">State to pass to the method.</param>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static void RunSync<TState>(Func<TState, ValueTask> task, TState state)
+        finally
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        }
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
+    /// <returns>The asynchronous result.</returns>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    public static T RunSync<T>(Func<Task<T>> task)
+    {
+        return RunSync(static state => state.Invoke(), task);
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
+    /// <param name="state">State to pass to the method.</param>
+    /// <returns>The asynchronous result.</returns>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    public static T RunSync<T, TState>(Func<TState, Task<T>> task, TState state)
+    {
+        var oldContext = SynchronizationContext.Current;
+        using var synch = new ExclusiveSynchronizationContext<TaskAwaiter<T>>(oldContext);
+        SynchronizationContext.SetSynchronizationContext(synch);
+        try
+        {
+            var awaiter = task(state).GetAwaiter();
+
+            if (!awaiter.IsCompleted)
             {
+                synch.Run(awaiter);
+            }
+            else
+            {
+                synch.RunAlreadyComplete();
+            }
+
+            // Throw any exception returned by the task or return the result
+            return awaiter.GetResult();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        }
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
+    /// <returns>The asynchronous result.</returns>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    [OverloadResolutionPriority(-1)]
+    public static T RunSync<T>(Func<ValueTask<T>> task)
+    {
+        return RunSync(static state => state.Invoke(), task);
+    }
+
+    /// <summary>
+    /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
+    /// </summary>
+    /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
+    /// <param name="state">State to pass to the method.</param>
+    /// <returns>The asynchronous result.</returns>
+    /// <remarks>
+    /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
+    /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
+    /// </remarks>
+    [OverloadResolutionPriority(-1)]
+    public static T RunSync<T, TState>(Func<TState, ValueTask<T>> task, TState state)
+    {
+        var oldContext = SynchronizationContext.Current;
+        using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter<T>>(oldContext);
+        SynchronizationContext.SetSynchronizationContext(synch);
+        try
+        {
 #pragma warning disable CA2012
-                var awaiter = task(state).GetAwaiter();
+            var awaiter = task(state).GetAwaiter();
 #pragma warning restore CA2012
 
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task
-                awaiter.GetResult();
-            }
-            finally
+            if (!awaiter.IsCompleted)
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                synch.Run(awaiter);
             }
+            else
+            {
+                synch.RunAlreadyComplete();
+            }
+
+            // Throw any exception returned by the task or return the result
+            return awaiter.GetResult();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        }
+    }
+
+    private readonly struct WorkItem(SendOrPostCallback callback, object? state)
+    {
+        public readonly SendOrPostCallback Callback = callback;
+        public readonly object? State = state;
+
+        public void Deconstruct(out SendOrPostCallback callback, out object? state)
+        {
+            callback = Callback;
+            state = State;
+        }
+    }
+
+    // Note: Sealing this class can help JIT make non-virtual method calls and inlined method calls for virtual methods
+    private sealed class ExclusiveSynchronizationContext<TAwaiter>(
+        SynchronizationContext? parentSynchronizationContext)
+        : SynchronizationContext, IDisposable
+        where TAwaiter : struct, ICriticalNotifyCompletion
+    {
+        private readonly BlockingCollection<WorkItem> _items = [];
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            throw new NotSupportedException("We cannot send to our same thread");
         }
 
-        /// <summary>
-        /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
-        /// <returns>The asynchronous result.</returns>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static T RunSync<T>(Func<Task<T>> task)
+        public override void Post(SendOrPostCallback d, object? state)
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter<T>>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
             try
             {
-                var awaiter = task().GetAwaiter();
-
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task or return the result
-                return awaiter.GetResult();
+                _items.Add(new WorkItem(d, state));
+                return;
             }
-            finally
+            catch (InvalidOperationException)
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                // This indicates the items cannot be added because the main loop
+                // is complete. We can't do a boolean check on IsAddingComplete because
+                // it will throw an ObjectDisposedException.
+            }
+
+            // The collection is closed to new items because we got done with the main task.
+            // Instead, we post any remaining work to the parent SynchronizationContext.
+            // This can occur if the main task starts additional work which isn't completed
+            // before the main task completes.
+
+            ExecuteOnParent(d, state);
+        }
+
+        private void EndMessageLoop()
+        {
+            // This method is only called when _items can still accept messages
+            Debug.Assert(!_items.IsAddingCompleted);
+
+            // We could post this onto the queue to be processed, but that's unnecessary because
+            // we're registered via OnCompleted on the awaiter. This will already marshal us onto
+            // this synchronization context.
+            //
+            // If we're already on this synchronization context when the main task completes,
+            // this continuation will be executed inline rather than queued in most cases.
+
+            _items.CompleteAdding();
+        }
+
+        public void Run(TAwaiter awaiter)
+        {
+            // Register a callback to run when the original awaiter is completed
+            // We use UnsafeOnCompleted so it doesn't flow ExecutionContext
+            awaiter.UnsafeOnCompleted(EndMessageLoop);
+
+            while (!_items.IsCompleted)
+            {
+                var (callback, state) = _items.Take();
+
+                callback(state);
             }
         }
 
-        /// <summary>
-        /// Executes an async <see cref="Task{T}"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="Task{T}"/> method to execute.</param>
-        /// <param name="state">State to pass to the method.</param>
-        /// <returns>The asynchronous result.</returns>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static T RunSync<T, TState>(Func<TState, Task<T>> task, TState state)
+        // Processes any remaining continuations in the queue
+        public void RunAlreadyComplete()
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<TaskAwaiter<T>>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
-            {
-                var awaiter = task(state).GetAwaiter();
+            EndMessageLoop();
 
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task or return the result
-                return awaiter.GetResult();
-            }
-            finally
+            while (!_items.IsCompleted)
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                var (callback, state) = _items.Take();
+
+                ExecuteOnParent(callback, state);
             }
         }
 
-        /// <summary>
-        /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
-        /// <returns>The asynchronous result.</returns>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static T RunSync<T>(Func<ValueTask<T>> task)
+        // Executes a work item on the parent SynchronizationContext or on the thread pool if there is not one
+        private void ExecuteOnParent(SendOrPostCallback callback, object? state)
         {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter<T>>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
+            if (parentSynchronizationContext != null)
             {
-#pragma warning disable CA2012
-                var awaiter = task().GetAwaiter();
-#pragma warning restore CA2012
-
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task or return the result
-                return awaiter.GetResult();
+                parentSynchronizationContext.Post(callback, state);
             }
-            finally
+            else
             {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
-            }
-        }
-
-        /// <summary>
-        /// Executes an async <see cref="ValueTask{T}"/> method which has a void return value synchronously.
-        /// </summary>
-        /// <param name="task"><see cref="ValueTask{T}"/> method to execute.</param>
-        /// <param name="state">State to pass to the method.</param>
-        /// <returns>The asynchronous result.</returns>
-        /// <remarks>
-        /// DO NOT use this method unless absolutely necessary. Calling async code from sync code is an anti-pattern
-        /// in most cases. This method is provided to assist in gradual conversion from sync to async code.
-        /// </remarks>
-        public static T RunSync<T, TState>(Func<TState, ValueTask<T>> task, TState state)
-        {
-            var oldContext = SynchronizationContext.Current;
-            using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter<T>>(oldContext);
-            SynchronizationContext.SetSynchronizationContext(synch);
-            try
-            {
-#pragma warning disable CA2012
-                var awaiter = task(state).GetAwaiter();
-#pragma warning restore CA2012
-
-                if (!awaiter.IsCompleted)
-                {
-                    synch.Run(awaiter);
-                }
-                else
-                {
-                    synch.RunAlreadyComplete();
-                }
-
-                // Throw any exception returned by the task or return the result
-                return awaiter.GetResult();
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(oldContext);
-            }
-        }
-
-        // Note: Sealing this class can help JIT make non-virtual method calls and inlined method calls for virtual methods
-        private sealed class ExclusiveSynchronizationContext<TAwaiter>(
-            SynchronizationContext? parentSynchronizationContext)
-            : SynchronizationContext, IDisposable
-            where TAwaiter : struct, ICriticalNotifyCompletion
-        {
-            private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _items = [];
-
-            public override void Send(SendOrPostCallback d, object? state)
-            {
-                throw new NotSupportedException("We cannot send to our same thread");
-            }
-
-            public override void Post(SendOrPostCallback d, object? state)
-            {
-                try
-                {
-                    _items.Add((d, state));
-                    return;
-                }
-                catch (InvalidOperationException)
-                {
-                    // This indicates the items cannot be added because the main loop
-                    // is complete. We can't do a boolean check on IsAddingComplete because
-                    // it will throw an ObjectDisposedException.
-                }
-
-                // The collection is closed to new items because we got done with the main task.
-                // Instead, we post any remaining work to the parent SynchronizationContext.
-                // This can occur if the main task starts additional work which isn't completed
-                // before the main task completes.
-
-                ExecuteOnParent(d, state);
-            }
-
-            private void EndMessageLoop()
-            {
-                // This method is only called when _items can still accept messages
-                Debug.Assert(!_items.IsAddingCompleted);
-
-                // We could post this onto the queue to be processed, but that's unnecessary because
-                // we're registered via OnCompleted on the awaiter. This will already marshal us onto
-                // this synchronization context.
-                //
-                // If we're already on this synchronization context when the main task completes,
-                // this continuation will be executed inline rather than queued in most cases.
-
-                _items.CompleteAdding();
-            }
-
-            public void Run(TAwaiter awaiter)
-            {
-                // Register a callback to run when the original awaiter is completed
-                // We use UnsafeOnCompleted so it doesn't flow ExecutionContext
-                awaiter.UnsafeOnCompleted(EndMessageLoop);
-
-                while (!_items.IsCompleted)
-                {
-                    var (callback, state) = _items.Take();
-
-                    callback(state);
-                }
-            }
-
-            // Processes any remaining continuations in the queue
-            public void RunAlreadyComplete()
-            {
-                EndMessageLoop();
-
-                while (!_items.IsCompleted)
-                {
-                    var (callback, state) = _items.Take();
-
-                    ExecuteOnParent(callback, state);
-                }
-            }
-
-            // Executes a work item on the parent SynchronizationContext or on the thread pool if there is not one
-            private void ExecuteOnParent(SendOrPostCallback callback, object? state)
-            {
-                if (parentSynchronizationContext != null)
-                {
-                    parentSynchronizationContext.Post(callback, state);
-                }
-                else
-                {
-                    // There is no parent sync context, so use the default behavior from the default
-                    // SynchronizationContext and post to the thread pool.
+                // There is no parent sync context, so use the default behavior from the default
+                // SynchronizationContext and post to the thread pool.
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                    ThreadPool.QueueUserWorkItem(static s => s.callback(s.state), (callback, state), preferLocal: false);
+                ThreadPool.QueueUserWorkItem(static s => s.Callback(s.State), new WorkItem(callback, state), preferLocal: false);
 #else
-                    ThreadPool.QueueUserWorkItem(static s =>
-                    {
-                        var state = ((SendOrPostCallback callback, object? state))s;
-                        state.callback(state.state);
-                    }, (callback, state));
+                ThreadPool.QueueUserWorkItem(static s =>
+                {
+                    var (callback, state) = (WorkItem)s;
+                    callback(state);
+                }, new WorkItem(callback, state));
 #endif
-                }
             }
+        }
 
-            public override SynchronizationContext CreateCopy()
-            {
-                return this;
-            }
+        public override SynchronizationContext CreateCopy()
+        {
+            return this;
+        }
 
-            public void Dispose()
-            {
-                _items.Dispose();
-            }
+        public void Dispose()
+        {
+            _items.Dispose();
         }
     }
 }

--- a/src/CenterEdge.Async/CenterEdge.Async.csproj
+++ b/src/CenterEdge.Async/CenterEdge.Async.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>13</LangVersion>
 
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -20,12 +21,16 @@
     <Description>Assists in the (risky) process of blocking a synchronous method waiting for an asynchronous Task to complete.</Description>
     <PackageTags>async threadpool deadlocks</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>    
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <Compile Remove="OverloadResolutionPriorityAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CenterEdge.Async/OverloadResolutionPriorityAttribute.cs
+++ b/src/CenterEdge.Async/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// Specifies the priority of a member in overload resolution. When unspecified, the default priority is 0.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+public
+#else
+internal
+#endif
+sealed class OverloadResolutionPriorityAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OverloadResolutionPriorityAttribute"/> class.
+    /// </summary>
+    /// <param name="priority">The priority of the attributed member. Higher numbers are prioritized, lower numbers are deprioritized. 0 is the default if no attribute is present.</param>
+    public OverloadResolutionPriorityAttribute(int priority)
+    {
+        Priority = priority;
+    }
+
+    /// <summary>
+    /// The priority of the member.
+    /// </summary>
+    public int Priority { get; }
+}


### PR DESCRIPTION
Motivation
----------
Keep up to date.

Modifications
-------------
- Drop the out-of-support .NET 6 target and add a .NET 9 target.
- Use file-scoped namespaces.
- Update various NuGet dependencies and update to xUnit v3.
- Update GitHub Actions and GitVersion.
- Switch to GitHubActionsTestLogger.
- Update to C# 13.
- Reduce code duplication by forwarding RunSync calls with no state to the methods which take state parameters. This may also reduce JIT code size in some scenarios.
- Add OverloadResolutionPriority to RunSync calls so C# 13 and later prefers the Task overload to the ValueTask overload. This simplifies usage by consumers.
- Use a strong type for work items instead of a ValueTuple.