### PR TITLE
Make ExclusiveSynchronizationContext less generic

### DIFF
--- a/src/CenterEdge.Async/AsyncHelper.cs
+++ b/src/CenterEdge.Async/AsyncHelper.cs
@@ -49,7 +49,7 @@ public static class AsyncHelper
     public static void RunSync<TState>(Func<TState, Task> task, TState state)
     {
         var oldContext = SynchronizationContext.Current;
-        using var synch = new ExclusiveSynchronizationContext<TaskAwaiter>(oldContext);
+        using var synch = new ExclusiveSynchronizationContext(oldContext);
         SynchronizationContext.SetSynchronizationContext(synch);
         try
         {
@@ -100,7 +100,7 @@ public static class AsyncHelper
     public static void RunSync<TState>(Func<TState, ValueTask> task, TState state)
     {
         var oldContext = SynchronizationContext.Current;
-        using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter>(oldContext);
+        using var synch = new ExclusiveSynchronizationContext(oldContext);
         SynchronizationContext.SetSynchronizationContext(synch);
         try
         {
@@ -153,7 +153,7 @@ public static class AsyncHelper
     public static T RunSync<T, TState>(Func<TState, Task<T>> task, TState state)
     {
         var oldContext = SynchronizationContext.Current;
-        using var synch = new ExclusiveSynchronizationContext<TaskAwaiter<T>>(oldContext);
+        using var synch = new ExclusiveSynchronizationContext(oldContext);
         SynchronizationContext.SetSynchronizationContext(synch);
         try
         {
@@ -206,7 +206,7 @@ public static class AsyncHelper
     public static T RunSync<T, TState>(Func<TState, ValueTask<T>> task, TState state)
     {
         var oldContext = SynchronizationContext.Current;
-        using var synch = new ExclusiveSynchronizationContext<ValueTaskAwaiter<T>>(oldContext);
+        using var synch = new ExclusiveSynchronizationContext(oldContext);
         SynchronizationContext.SetSynchronizationContext(synch);
         try
         {

--- a/src/CenterEdge.Async/ExclusiveSynchronizationContext.cs
+++ b/src/CenterEdge.Async/ExclusiveSynchronizationContext.cs
@@ -7,10 +7,9 @@ using System.Threading;
 namespace CenterEdge.Async;
 
 // Note: Sealing this class can help JIT make non-virtual method calls and inlined method calls for virtual methods
-internal sealed class ExclusiveSynchronizationContext<TAwaiter>(
+internal sealed class ExclusiveSynchronizationContext(
     SynchronizationContext? parentSynchronizationContext)
     : SynchronizationContext, IDisposable
-    where TAwaiter : struct, ICriticalNotifyCompletion
 {
     private readonly BlockingCollection<WorkItem> _items = [];
 
@@ -56,7 +55,8 @@ internal sealed class ExclusiveSynchronizationContext<TAwaiter>(
         _items.CompleteAdding();
     }
 
-    public void Run(TAwaiter awaiter)
+    public void Run<TAwaiter>(TAwaiter awaiter)
+        where TAwaiter : struct, ICriticalNotifyCompletion
     {
         // Register a callback to run when the original awaiter is completed
         // We use UnsafeOnCompleted so it doesn't flow ExecutionContext


### PR DESCRIPTION
Motivation
----------
This may reduce JIT/AOT code size in some scenarios by moving some methods not impacted by the type of the awaiter out of the generic context.