### PR TITLE
Reduce thread pool depletion issues on modern .NET

### DIFF
--- a/src/CenterEdge.Async.UnitTests/ThreadPoolDepletionTests.cs
+++ b/src/CenterEdge.Async.UnitTests/ThreadPoolDepletionTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CenterEdge.Async.UnitTests;
+
+public class ThreadPoolDepletionTests
+{
+    [Fact]
+    public void ReproThreadPoolDepletion()
+    {
+        // This test demonstrates running a single-threaded synchronization context,
+        // Using AsyncHelper.RunSync from this context, using ConfigureAwait(false) to
+        // get off the context and onto the thread pool, and then using AsyncHelper.RunSync
+        // again from the thread pool thread. This is a contrived example that could happen
+        // in multi-layer architectures where some layers are async and some are sync.
+        // In older .NET, this test will run slowly due to thread pool depletion and the
+        // hill climbing algorithm for adding threads to the pool. But in modern .NET (6.0+)
+        // this test should run quickly because it recognizes we're waiting on tasks in a
+        // thread pool thread.
+
+        static async Task DoAnotherAsyncThing()
+        {
+            await Task.Delay(1).ConfigureAwait(false);
+        }
+
+        static void DoSyncThing()
+        {
+            AsyncHelper.RunSync(DoAnotherAsyncThing);
+        }
+
+        static async Task DoAsyncThing()
+        {
+            await Task.Delay(1).ConfigureAwait(false);
+
+            // We're on the thread pool here due to ConfigureAwait(false)
+            DoSyncThing();
+        }
+
+        var sw = Stopwatch.StartNew();
+
+        var tasks = new List<Task>();
+        for (var i = 0; i < Environment.ProcessorCount * 4; i++)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            tasks.Add(tcs.Task);
+
+            new Thread(() =>
+            {
+                try
+                {
+                    SingleThreadedSynchronizationContext.Run(() =>
+                    {
+                        AsyncHelper.RunSync(DoAsyncThing);
+                    });
+                }
+                finally
+                {
+                    tcs.TrySetResult(null);
+                }
+            })
+            { IsBackground = true }.Start();
+        }
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([.. tasks], TestContext.Current.CancellationToken);
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
+        sw.Stop();
+
+        TestContext.Current.TestOutputHelper?.WriteLine($"Elapsed: {sw.Elapsed.TotalMilliseconds}ms");
+    }
+
+    internal sealed class SingleThreadedSynchronizationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new BlockingCollection<(SendOrPostCallback Callback, object? State)>();
+
+        public override void Send(SendOrPostCallback d, object? state) // Sync operations
+        {
+            throw new NotSupportedException($"{nameof(SingleThreadedSynchronizationContext)} does not support synchronous operations.");
+        }
+
+        public override void Post(SendOrPostCallback d, object? state) // Async operations
+        {
+            _queue.Add((d, state));
+        }
+
+        public static void Run(Action action)
+        {
+            var previous = Current;
+            var context = new SingleThreadedSynchronizationContext();
+            SetSynchronizationContext(context);
+            try
+            {
+                action();
+
+                while (context._queue.TryTake(out var item))
+                {
+                    item.Callback(item.State);
+                }
+            }
+            finally
+            {
+                context._queue.CompleteAdding();
+                SetSynchronizationContext(previous);
+            }
+        }
+    }
+}

--- a/src/CenterEdge.Async/AsyncHelper.cs
+++ b/src/CenterEdge.Async/AsyncHelper.cs
@@ -25,7 +25,7 @@ public static class AsyncHelper
     //     });
 
     // If there is no SynchronizationContext or if the current SynchronizationContext is the default one, and if there
-    // is not a custom TaskScheduler, then it is safe to run the task directly without risk of deadlock. This reduces
+    // is no custom TaskScheduler, then it is safe to run the task directly without risk of deadlock. This reduces
     // overhead and improves the speed of continuations because we don't need to use the ExclusiveSynchronizationContext.
     // Also, this is particularly valuable in cases where the thread being blocked is a thread pool thread. Modern .NET
     // includes optimizations which reduce the risk of thread pool depletion and otherwise improves performance when


### PR DESCRIPTION
Motivation
----------
.NET 6 and later includes special logic to recognize when a thread pool thread is blocked waiting on a Task to complete, which is generally also waiting on a thread pool thread. When safe to do so, we should block on the task directly rather than using
ExclusiveSynchronizationContext so that .NET can recognize the case and grow the thread pool more aggressively. This also reduces other overhead as well, improving overall performance.

Modifications
-------------
When RunSync is called with no or the default SynchronizationContext and no custom TaskScheduler, just block directly on the returned awaiter rather than constructing an ExclusiveSynchronizationContext.